### PR TITLE
Update to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Detect unused dependencies in a rust project'
 author: 'Aaron Griffin'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 
 inputs:


### PR DESCRIPTION
Actions now report warnings because of https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
This PR fixes the warnings