### PR TITLE
chore: migrate to node20 and fix typo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Detect unused dependencies in a rust project'
 author: 'Aaron Griffin'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 inputs:
@@ -12,7 +12,7 @@ inputs:
     required: true
     default: 'latest'
   target:
-    description:  'Binary target to downloag'
+    description:  'Binary target to download'
     required: true
     default: 'x86_64-unknown-linux-gnu'
   args:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "cargo-udeps-action",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions-rs/core": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cargo-udeps-action",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Detect unused dependencies in a rust project",
   "main": "lib/main.js",
   "directories": {


### PR DESCRIPTION
As per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/, this action needs to migrate to `node20`. I've gone ahead and updated the `using` as suggested in the article.